### PR TITLE
Add hardware_info to csrc

### DIFF
--- a/csrc/src/hardware_info.h
+++ b/csrc/src/hardware_info.h
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Copyright (c) 2024, Tri Dao.
+ ******************************************************************************/
+
+#pragma once
+
+#include <tuple>
+
+#if !defined(__CUDACC_RTC__)
+#include "cuda_runtime.h"
+#endif
+
+#define CHECK_CUDA(call)                                                       \
+  do {                                                                         \
+    cudaError_t status_ = call;                                                \
+    if (status_ != cudaSuccess) {                                              \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__,          \
+              cudaGetErrorString(status_));                                    \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+
+inline int get_current_device() {
+    int device;
+    CHECK_CUDA(cudaGetDevice(&device));
+    return device;
+}
+
+inline std::tuple<int, int> get_compute_capability(int device) {
+    int capability_major, capability_minor;
+    CHECK_CUDA(cudaDeviceGetAttribute(&capability_major, cudaDevAttrComputeCapabilityMajor, device));
+    CHECK_CUDA(cudaDeviceGetAttribute(&capability_minor, cudaDevAttrComputeCapabilityMinor, device));
+    return {capability_major, capability_minor};
+}
+
+inline int get_num_sm(int device) {
+    int multiprocessor_count;
+    CHECK_CUDA(cudaDeviceGetAttribute(&multiprocessor_count, cudaDevAttrMultiProcessorCount, device));
+    return multiprocessor_count;
+}


### PR DESCRIPTION
This pull request introduces a new header file, `csrc/src/hardware_info.h`, that provides utility functions for querying CUDA hardware information. The changes include the addition of macros and inline functions to streamline CUDA device queries.

### Key changes:

#### New utility functions for CUDA hardware queries:
* Added the `CHECK_CUDA` macro to handle CUDA API error checking with descriptive error messages and program termination on failure.
* Implemented `get_current_device` to retrieve the currently active CUDA device.
* Added `get_compute_capability` to fetch the compute capability (major and minor version) of a specified CUDA device.
* Created `get_num_sm` to obtain the number of streaming multiprocessors (SMs) on a given CUDA device.