### PR TITLE
Add block_info to csrc

### DIFF
--- a/csrc/src/block_info.h
+++ b/csrc/src/block_info.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright (c) 2023, Tri Dao.
+ ******************************************************************************/
+
+#pragma once
+
+#include "namespace_config.h"
+namespace FLASH_NAMESPACE {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template<bool Varlen=true>
+struct BlockInfo {
+
+    template<typename Params>
+    __device__ BlockInfo(const Params &params, const int bidb)
+        : sum_s_q(!Varlen || params.cu_seqlens_q == nullptr ? -1 : params.cu_seqlens_q[bidb])
+        , sum_s_k(!Varlen || params.cu_seqlens_k == nullptr || !params.is_seqlens_k_cumulative ? -1 : params.cu_seqlens_k[bidb])
+        , actual_seqlen_q(!Varlen || params.cu_seqlens_q == nullptr ? params.seqlen_q : params.cu_seqlens_q[bidb + 1] - sum_s_q)
+        // If is_seqlens_k_cumulative, then seqlen_k is cu_seqlens_k[bidb + 1] - cu_seqlens_k[bidb].
+        // Otherwise it's cu_seqlens_k[bidb], i.e., we use cu_seqlens_k to store the sequence lengths of K.
+        , leftpad_k(params.leftpad_k == nullptr ? 0 : params.leftpad_k[bidb])
+        , seqlen_k_cache((!Varlen || params.cu_seqlens_k == nullptr ? params.seqlen_k : (params.is_seqlens_k_cumulative ? params.cu_seqlens_k[bidb + 1] - sum_s_k : params.cu_seqlens_k[bidb])) - leftpad_k)
+        , actual_seqlen_k(params.seqused_k ? params.seqused_k[bidb] - leftpad_k : seqlen_k_cache + (params.knew_ptr == nullptr ? 0 : params.seqlen_knew))
+        {
+        }
+
+    template <typename index_t>
+    __forceinline__ __device__ index_t q_offset(const index_t batch_stride, const index_t row_stride, const int bidb) const {
+        return sum_s_q == -1 ? bidb * batch_stride : uint32_t(sum_s_q) * row_stride;
+    }
+
+    template <typename index_t>
+    __forceinline__ __device__ index_t k_offset(const index_t batch_stride, const index_t row_stride, const int bidb) const {
+        return sum_s_k == -1 ? bidb * batch_stride + leftpad_k * row_stride : uint32_t(sum_s_k + leftpad_k) * row_stride;
+    }
+
+    const int sum_s_q;
+    const int sum_s_k;
+    const int actual_seqlen_q;
+    // We have to have seqlen_k_cache declared before actual_seqlen_k, otherwise actual_seqlen_k is set to 0.
+    const int leftpad_k;
+    const int seqlen_k_cache;
+    const int actual_seqlen_k;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace FLASH_NAMESPACE


### PR DESCRIPTION
This pull request introduces a new `BlockInfo` struct in the `csrc/src/block_info.h` file to manage sequence length and padding information for query and key sequences. The struct is designed for use in GPU kernels, with support for variable-length sequences and efficient offset calculations.

### Key Changes:

#### New `BlockInfo` Struct:
* Added a templated `BlockInfo` struct with a boolean template parameter `Varlen` to handle variable-length sequences. It includes logic for initializing sequence-related parameters like cumulative sequence lengths, actual sequence lengths, and padding. (`[csrc/src/block_info.hR1-R49](diffhunk://#diff-394b0098afb828601be7aad41de4a4125220493eb2b3bf4e768797a39757beaeR1-R49)`)

#### Offset Calculation Methods:
* Introduced `q_offset` and `k_offset` methods to compute memory offsets for query and key sequences based on batch and row strides. These methods are optimized for GPU execution with `__forceinline__` and `__device__` qualifiers. (`[csrc/src/block_info.hR1-R49](diffhunk://#diff-394b0098afb828601be7aad41de4a4125220493eb2b3bf4e768797a39757beaeR1-R49)`)

#### Namespace and Header Updates:
* Wrapped the new struct in the `FLASH_NAMESPACE` namespace for modularity and included necessary headers like `namespace_config.h`. (`[csrc/src/block_info.hR1-R49](diffhunk://#diff-394b0098afb828601be7aad41de4a4125220493eb2b3bf4e768797a39757beaeR1-R49)`)